### PR TITLE
Calculo dos dados de perfil

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       "ts"
     ],
     "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
+    "testRegex": ".*\\.test\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/src/contracts/entities/IProfileData.ts
+++ b/src/contracts/entities/IProfileData.ts
@@ -22,7 +22,7 @@ export interface IProfileData {
   timelineSampleHashtagCount: number;
   timelineSampleMentionCount: number;
   timelineSamplePostCreatedAtDates: Date[];
-  mentions: Record<string, number>;
-  hashtags: Record<string, number>;
-  retweets: Record<string, number>;
+  mentions: Map<string, number>;
+  hashtags: Map<string, number>;
+  retweets: Map<string, number>;
 }

--- a/src/contracts/entities/IProfileData.ts
+++ b/src/contracts/entities/IProfileData.ts
@@ -20,7 +20,6 @@ export interface IProfileData {
   timelineSampleUserTweetSize: number /** quantos tweets sao tweets propios */;
   timelineSampleUserTweetTextSizeAvg: number /** media do tamanho dos tweets 0-280 */;
   timelineSampleHashtagCount: number;
-  timelineSampleRetweetCount: number;
   timelineSampleMentionCount: number;
   timelineSamplePostCreatedAtDates: Date[];
   mentions: Record<string, number>;

--- a/src/entities/ProfileData.test.ts
+++ b/src/entities/ProfileData.test.ts
@@ -1,0 +1,65 @@
+import { ProfileData } from './ProfileData';
+
+describe('ProfileData', () => {
+  const sampleInput = {
+    nTweet: 10,
+    nFollower: 100,
+    nFollowing: 50,
+    location: 'Brazil',
+    username: 'john123',
+    name: 'John Doe',
+    description: 'Sample description',
+    createdAt: '2022-01-01T00:00:00.000Z',
+    tweets: [
+      {
+        text: 'Hello world #Twitter',
+        mentions: [],
+        isReply: false,
+        isRetweet: false,
+      },
+      {
+        text: '@bob789 Retweet tweet',
+        mentions: [{ username: 'bob789', id: '456' }],
+        isReply: false,
+        isRetweet: true,
+      },
+      {
+        text: '@alice321 @bob789 Reply tweet',
+        mentions: [
+          { username: 'alice321', id: '789' },
+          { username: 'bob789', id: '456' },
+        ],
+        isReply: true,
+        isRetweet: false,
+      },
+    ],
+  };
+
+  it('should create an instance of ProfileData with correct property values', () => {
+    const profileData = new ProfileData(sampleInput);
+
+    expect(profileData.nTweet).toBe(10);
+    expect(profileData.nFollower).toBe(100);
+    expect(profileData.nFollowing).toBe(50);
+    expect(profileData.location).toBe('Brazil');
+    expect(profileData.hasLocation).toBe(true);
+    expect(profileData.username).toBe('john123');
+    expect(profileData.usernameSize).toBe(7);
+    expect(profileData.name).toBe('John Doe');
+    expect(profileData.nameSize).toBe(8);
+    expect(profileData.descriptionSize).toBe(18);
+    expect(profileData.nNumberUsername).toBe(3);
+    expect(profileData.nLettersUsername).toBe(4);
+    expect(profileData.accountAgeInDays).toBeGreaterThan(0);
+    expect(profileData.timelineSampleFullSize).toBe(3);
+    expect(profileData.timelineSampleReplySize).toBe(1);
+    expect(profileData.timelineSampleRetweetSize).toBe(1);
+    expect(profileData.timelineSampleUserTweetSize).toBe(2);
+    expect(profileData.timelineSampleUserTweetTextSizeAvg).toBe(24.5);
+    expect(profileData.timelineSampleHashtagCount).toBe(1);
+    expect(profileData.timelineSampleMentionCount).toBe(2);
+    expect(profileData.mentions.get('@alice321')).toBe(1);
+    expect(profileData.mentions.get('@bob789')).toBe(2);
+    expect(profileData.hashtags.get('#Twitter')).toBe(1);
+  });
+});

--- a/src/entities/ProfileData.ts
+++ b/src/entities/ProfileData.ts
@@ -1,15 +1,17 @@
 import { IProfileData } from 'contracts/entities/IProfileData';
 
+type InpuTweetType = {
+  text: string;
+  mentions?: { username: string; id: string }[];
+  isReply: boolean;
+  isRetweet: boolean;
+};
+
 export type InputProfileData = Pick<
   IProfileData,
   'nTweet' | 'nFollower' | 'nFollowing' | 'location' | 'username' | 'name'
 > & {
-  tweets: {
-    text: string;
-    mentions?: { username: string; id: string }[];
-    isReply: boolean;
-    isRetweet: boolean;
-  }[];
+  tweets: InpuTweetType[];
   description: string;
   createdAt: string;
 };
@@ -25,16 +27,17 @@ export class ProfileData implements IProfileData {
   readonly name: string;
   readonly nameSize: number;
   readonly descriptionSize: number;
-  nNumberUsername: number;
-  nLettersUsername: number;
-  accountAgeInDays: number;
-  timelineSampleFullSize: number;
-  timelineSampleReplySize: number;
-  timelineSampleRetweetSize: number;
-  timelineSampleUserTweetSize: number;
+  readonly nNumberUsername: number;
+  readonly nLettersUsername: number;
+  readonly accountAgeInDays: number;
+
+  readonly timelineSampleFullSize: number;
+  readonly timelineSampleReplySize: number;
+  readonly timelineSampleRetweetSize: number;
+  readonly timelineSampleUserTweetSize: number;
+
   timelineSampleUserTweetTextSizeAvg: number;
   timelineSampleHashtagCount: number;
-  timelineSampleRetweetCount: number;
   timelineSampleMentionCount: number;
   timelineSamplePostCreatedAtDates: Date[];
   mentions: Record<string, number>;
@@ -52,10 +55,15 @@ export class ProfileData implements IProfileData {
     this.name = props.name;
     this.nameSize = props.name.length;
     this.descriptionSize = props.description.length;
+    this.timelineSampleFullSize = props.tweets.length;
 
     this.nNumberUsername = this.getNumbersLengthFromString();
     this.nLettersUsername = this.getLettersLengthFromString();
     this.accountAgeInDays = this.countDaysBetweenDates(props.createdAt);
+
+    this.timelineSampleRetweetSize = this.calculateRetweet(props.tweets);
+    this.timelineSampleReplySize = this.calculateReply(props.tweets);
+    this.timelineSampleUserTweetSize = this.calculateUserTweets(props.tweets);
   }
 
   private getLettersLengthFromString(): number {
@@ -78,5 +86,26 @@ export class ProfileData implements IProfileData {
     const timeDifference = today.getTime() - pastDate.getTime();
     const dayDifference = Math.floor(timeDifference / (1000 * 60 * 60 * 24));
     return dayDifference;
+  }
+
+  private calculateRetweet(tweets: Array<InpuTweetType>): number {
+    return tweets.reduce(
+      (count, tweet) => (tweet.isRetweet ? count + 1 : count),
+      0,
+    );
+  }
+
+  private calculateReply(tweets: Array<InpuTweetType>): number {
+    return tweets.reduce(
+      (count, tweet) => (tweet.isReply ? count + 1 : count),
+      0,
+    );
+  }
+
+  private calculateUserTweets(tweets: Array<InpuTweetType>): number {
+    return tweets.reduce(
+      (count, tweet) => (!tweet.isRetweet ? count + 1 : count),
+      0,
+    );
   }
 }

--- a/src/entities/ProfileData.ts
+++ b/src/entities/ProfileData.ts
@@ -16,6 +16,9 @@ export type InputProfileData = Pick<
   createdAt: string;
 };
 
+const mentionRegex = /@(\w+)/g;
+const hashtagRegex = /#(\w+)/g;
+
 export class ProfileData implements IProfileData {
   readonly nTweet: number;
   readonly nFollower: number;
@@ -37,9 +40,10 @@ export class ProfileData implements IProfileData {
   readonly timelineSampleUserTweetSize: number;
 
   readonly timelineSampleUserTweetTextSizeAvg: number;
-  timelineSampleHashtagCount: number;
-  timelineSampleMentionCount: number;
+  readonly timelineSampleHashtagCount: number;
+  readonly timelineSampleMentionCount: number;
   timelineSamplePostCreatedAtDates: Date[];
+
   mentions: Record<string, number>;
   hashtags: Record<string, number>;
   retweets: Record<string, number>;
@@ -68,6 +72,9 @@ export class ProfileData implements IProfileData {
     this.timelineSampleUserTweetTextSizeAvg = this.tweetAvgTextSize(
       props.tweets,
     );
+
+    this.timelineSampleHashtagCount = this.countHashtags(props.tweets);
+    this.timelineSampleMentionCount = this.countMentions(props.tweets);
   }
 
   private getLettersLengthFromString(): number {
@@ -125,5 +132,19 @@ export class ProfileData implements IProfileData {
     );
 
     return totalLength / userTweets.length;
+  }
+
+  private countHashtags(tweets: Array<InpuTweetType>): number {
+    return tweets.reduce((total, tweet) => {
+      const matches = tweet.text.match(hashtagRegex);
+      return total + (matches ? matches.length : 0);
+    }, 0);
+  }
+
+  private countMentions(tweets: Array<InpuTweetType>): number {
+    return tweets.reduce((total, tweet) => {
+      const matches = tweet.text.match(mentionRegex);
+      return total + (matches ? matches.length : 0);
+    }, 0);
   }
 }

--- a/src/entities/ProfileData.ts
+++ b/src/entities/ProfileData.ts
@@ -44,8 +44,8 @@ export class ProfileData implements IProfileData {
   readonly timelineSampleMentionCount: number;
   timelineSamplePostCreatedAtDates: Date[];
 
-  mentions: Map<string, number>;
-  hashtags: Map<string, number>;
+  readonly mentions: Map<string, number>;
+  readonly hashtags: Map<string, number>;
   retweets: Map<string, number>;
 
   constructor(props: InputProfileData) {

--- a/src/entities/ProfileData.ts
+++ b/src/entities/ProfileData.ts
@@ -16,7 +16,6 @@ export type InputProfileData = Pick<
   createdAt: string;
 };
 
-const mentionRegex = /@(\w+)/g;
 const hashtagRegex = /#(\w+)/g;
 
 export class ProfileData implements IProfileData {
@@ -44,9 +43,9 @@ export class ProfileData implements IProfileData {
   readonly timelineSampleMentionCount: number;
   timelineSamplePostCreatedAtDates: Date[];
 
-  mentions: Record<string, number>;
-  hashtags: Record<string, number>;
-  retweets: Record<string, number>;
+  mentions: Map<string, number>;
+  hashtags: Map<string, number>;
+  retweets: Map<string, number>;
 
   constructor(props: InputProfileData) {
     this.nTweet = props.nTweet;
@@ -143,8 +142,9 @@ export class ProfileData implements IProfileData {
 
   private countMentions(tweets: Array<InpuTweetType>): number {
     return tweets.reduce((total, tweet) => {
-      const matches = tweet.text.match(mentionRegex);
-      return total + (matches ? matches.length : 0);
+      return (
+        total + (tweet.mentions && !tweet.isRetweet ? tweet.mentions.length : 0)
+      );
     }, 0);
   }
 }

--- a/src/entities/ProfileData.ts
+++ b/src/entities/ProfileData.ts
@@ -36,7 +36,7 @@ export class ProfileData implements IProfileData {
   readonly timelineSampleRetweetSize: number;
   readonly timelineSampleUserTweetSize: number;
 
-  timelineSampleUserTweetTextSizeAvg: number;
+  readonly timelineSampleUserTweetTextSizeAvg: number;
   timelineSampleHashtagCount: number;
   timelineSampleMentionCount: number;
   timelineSamplePostCreatedAtDates: Date[];
@@ -64,6 +64,10 @@ export class ProfileData implements IProfileData {
     this.timelineSampleRetweetSize = this.calculateRetweet(props.tweets);
     this.timelineSampleReplySize = this.calculateReply(props.tweets);
     this.timelineSampleUserTweetSize = this.calculateUserTweets(props.tweets);
+
+    this.timelineSampleUserTweetTextSizeAvg = this.tweetAvgTextSize(
+      props.tweets,
+    );
   }
 
   private getLettersLengthFromString(): number {
@@ -107,5 +111,19 @@ export class ProfileData implements IProfileData {
       (count, tweet) => (!tweet.isRetweet ? count + 1 : count),
       0,
     );
+  }
+
+  private tweetAvgTextSize(tweets: Array<InpuTweetType>): number {
+    if (tweets.length === 0) return 0;
+
+    const userTweets = tweets.filter((tweet) => !tweet.isRetweet);
+    if (userTweets.length === 0) return 0;
+
+    const totalLength = userTweets.reduce(
+      (total, tweet) => total + tweet.text.length,
+      0,
+    );
+
+    return totalLength / userTweets.length;
   }
 }

--- a/src/entities/ProfileData.ts
+++ b/src/entities/ProfileData.ts
@@ -16,6 +16,7 @@ export type InputProfileData = Pick<
   createdAt: string;
 };
 
+const mentionRegex = /@(\w+)/g;
 const hashtagRegex = /#(\w+)/g;
 
 export class ProfileData implements IProfileData {
@@ -74,6 +75,9 @@ export class ProfileData implements IProfileData {
 
     this.timelineSampleHashtagCount = this.countHashtags(props.tweets);
     this.timelineSampleMentionCount = this.countMentions(props.tweets);
+
+    this.mentions = this.mapMentions(props.tweets);
+    this.hashtags = this.mapHashtags(props.tweets);
   }
 
   private getLettersLengthFromString(): number {
@@ -146,5 +150,35 @@ export class ProfileData implements IProfileData {
         total + (tweet.mentions && !tweet.isRetweet ? tweet.mentions.length : 0)
       );
     }, 0);
+  }
+
+  private mapMentions(tweets: Array<InpuTweetType>): Map<string, number> {
+    const mapOfMentions = new Map<string, number>();
+    for (const tweet of tweets) {
+      const mentions = tweet.text.match(mentionRegex);
+      if (mentions) {
+        for (const mention of mentions) {
+          if (!mapOfMentions.has(mention)) mapOfMentions.set(mention, 0);
+          mapOfMentions.set(mention, mapOfMentions.get(mention) + 1);
+        }
+      }
+    }
+
+    return mapOfMentions;
+  }
+
+  private mapHashtags(tweets: Array<InpuTweetType>): Map<string, number> {
+    const mapOfHashtags = new Map<string, number>();
+    for (const tweet of tweets) {
+      const hashtags = tweet.text.match(hashtagRegex);
+      if (hashtags) {
+        for (const mention of hashtags) {
+          if (!mapOfHashtags.has(mention)) mapOfHashtags.set(mention, 0);
+          mapOfHashtags.set(mention, mapOfHashtags.get(mention) + 1);
+        }
+      }
+    }
+
+    return mapOfHashtags;
   }
 }

--- a/src/infra/database/schemas/ProfileDataSchema.ts
+++ b/src/infra/database/schemas/ProfileDataSchema.ts
@@ -23,7 +23,6 @@ export const ProfileDataSchema = new Schema<IProfileData>(
     timelineSampleUserTweetSize: { type: Number },
     timelineSampleUserTweetTextSizeAvg: { type: Number },
     timelineSampleHashtagCount: { type: Number },
-    timelineSampleRetweetCount: { type: Number },
     timelineSampleMentionCount: { type: Number },
     timelineSamplePostCreatedAtDates: [{ type: Date }],
     mentions: { type: Object },


### PR DESCRIPTION
Calcula os dados de perfil definidos por ProfileData
Falta `timelineSamplePostCreatedAtDates` pq os dados da integração aindanão tem a data de criação dos tweets e `retweets` pq ainda não sei se vou fazer um map dos retweet (não sei se precisa, fica aí por enquanto) 

````
export interface IProfileData {
  /** Dados do usário */
  nTweet: number;
  nFollower: number;
  nFollowing: number;
  location: string;
  hasLocation: boolean;
  username: string;
  usernameSize: number;
  nNumberUsername: number;
  nLettersUsername: number;
  name: string;
  nameSize: number;
  descriptionSize: number;
  accountAgeInDays: number;
  timelineSampleFullSize: number /** total de tweets no sample, pode ser de 0 até o sample definido na integração (provavelmente 30) */;
  timelineSampleReplySize: number /** quantos tweets sao reply */;
  timelineSampleRetweetSize: number /** quantos tweets sao retweet */;
  timelineSampleUserTweetSize: number /** quantos tweets sao tweets propios */;
  timelineSampleUserTweetTextSizeAvg: number /** media do tamanho dos tweets 0-280 */;
  timelineSampleHashtagCount: number;
  timelineSampleMentionCount: number;
  timelineSamplePostCreatedAtDates: Date[];
  mentions: Map<string, number>;
  hashtags: Map<string, number>;
  retweets: Map<string, number>;
}